### PR TITLE
Add minimal devcontainer configuration for ESP32-C6 development

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,84 @@
+# Development Container Configuration
+
+This directory contains the devcontainer configuration for the Fevicol ESP32-C6 project.
+
+## What's Included
+
+The devcontainer provides a complete development environment with:
+
+- **Rust toolchain** (stable) with RISC-V target support
+- **probe-rs-tools** for flashing and debugging ESP32-C6
+- **rust-src** component for `no_std` bare-metal builds
+- **VS Code extensions** for Rust development
+- **USB passthrough** for connecting to physical hardware
+
+## Quick Start
+
+### Using VS Code
+
+1. Install the "Dev Containers" extension in VS Code
+2. Open the project folder
+3. Click "Reopen in Container" when prompted (or use Command Palette → "Dev Containers: Reopen in Container")
+4. Wait for the container to build and setup to complete
+
+### Using GitHub Codespaces
+
+1. Click "Code" → "Codespaces" → "Create codespace on \<branch\>"
+2. Wait for the environment to initialize
+3. The project will be ready to build and test
+
+## Building and Testing
+
+Once inside the container:
+
+```bash
+# Build the project
+cargo build
+
+# Run tests
+cargo test
+
+# Check formatting
+cargo fmt --all -- --check
+
+# Run linter
+cargo clippy --all-features --workspace -- -D warnings
+```
+
+## Flashing to Hardware
+
+To flash firmware to a connected ESP32-C6 device:
+
+1. Connect the device via USB
+2. The container has USB passthrough enabled with `--privileged` mode
+3. Run: `cargo run`
+
+Note: USB passthrough works best with Docker Desktop or local VS Code with Dev Containers. It may have limitations in browser-based Codespaces.
+
+## Configuration Details
+
+- **Base Image**: Microsoft Rust devcontainer (Debian Bookworm)
+- **Post-Create Setup**: Automatically installs probe-rs and configures Rust target
+- **USB Access**: Configured for ESP32 USB devices (vendor IDs: 303a, 10c4)
+- **VS Code Settings**: Pre-configured rust-analyzer for RISC-V embedded development
+
+## Troubleshooting
+
+### probe-rs not found
+The setup script installs probe-rs automatically. If missing, run:
+```bash
+cargo install probe-rs-tools --locked
+```
+
+### USB device not accessible
+Check that:
+- The container is running with `--privileged` flag
+- USB device is connected and visible: `lsusb`
+- udev rules are loaded: `sudo udevadm control --reload-rules`
+
+### Build errors
+Ensure all components are installed:
+```bash
+rustup target add riscv32imac-unknown-none-elf
+rustup component add rust-src
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+	"name": "Fevicol ESP32-C6 Dev Container",
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
+
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": true,
+			"configureZshAsDefaultShell": true,
+			"installOhMyZsh": true
+		}
+	},
+
+	"postCreateCommand": "bash .devcontainer/setup.sh",
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml",
+				"serayuzgur.crates"
+			],
+			"settings": {
+				"rust-analyzer.checkOnSave.allTargets": false,
+				"rust-analyzer.cargo.target": "riscv32imac-unknown-none-elf",
+				"rust-analyzer.cargo.features": "all"
+			}
+		}
+	},
+
+	"mounts": [
+		"source=/dev/bus/usb,target=/dev/bus/usb,type=bind"
+	],
+
+	"runArgs": [
+		"--privileged"
+	],
+
+	"remoteEnv": {
+		"DEFMT_LOG": "info"
+	}
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+echo "Setting up Fevicol development environment..."
+
+# Install probe-rs tools for flashing and debugging
+echo "Installing probe-rs-tools..."
+cargo install probe-rs-tools --locked
+
+# Install the required Rust target
+echo "Adding RISC-V target..."
+rustup target add riscv32imac-unknown-none-elf
+
+# Install rust-src component for build-std
+echo "Adding rust-src component..."
+rustup component add rust-src
+
+# Install useful development tools
+echo "Installing additional tools..."
+cargo install cargo-expand || true
+
+# Set up udev rules for probe-rs (if running with USB passthrough)
+echo "Configuring USB permissions..."
+cat > /tmp/99-probe-rs.rules << 'EOF'
+# probe-rs rules
+SUBSYSTEM=="usb", ATTR{idVendor}=="303a", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="10c4", MODE="0666"
+EOF
+sudo mv /tmp/99-probe-rs.rules /etc/udev/rules.d/ || true
+sudo udevadm control --reload-rules || true
+sudo udevadm trigger || true
+
+echo "Development environment setup complete!"
+echo ""
+echo "You can now:"
+echo "  - Build the project: cargo build"
+echo "  - Run tests: cargo test"
+echo "  - Flash to device: cargo run (requires connected ESP32-C6)"
+echo ""


### PR DESCRIPTION
This adds a complete development container setup that enables building and testing the Fevicol project without local Rust toolchain installation.

Features:
- Debian-based Rust devcontainer with stable toolchain
- Automatic installation of probe-rs-tools for ESP32-C6 flashing
- RISC-V target (riscv32imac-unknown-none-elf) configuration
- rust-src component for no_std bare-metal builds
- USB passthrough for connecting to physical hardware
- VS Code extensions and settings for embedded Rust development
- udev rules for probe-rs USB device access

The setup script automatically configures the environment on container creation, ensuring all dependencies are installed and ready for cargo build/test/run.