### PR TITLE
Fix devcontainer configuration for CI/CD compatibility

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -47,20 +47,53 @@ cargo clippy --all-features --workspace -- -D warnings
 
 ## Flashing to Hardware
 
-To flash firmware to a connected ESP32-C6 device:
+The default configuration is optimized for CI/CD environments and does not include USB passthrough. To flash firmware to a physical ESP32-C6 device, you need to enable USB access:
 
-1. Connect the device via USB
-2. The container has USB passthrough enabled with `--privileged` mode
-3. Run: `cargo run`
+### Option 1: Local devcontainer.json Override
 
-Note: USB passthrough works best with Docker Desktop or local VS Code with Dev Containers. It may have limitations in browser-based Codespaces.
+Create `.devcontainer/devcontainer.local.json` (git-ignored):
+
+```json
+{
+	"mounts": [
+		"source=/dev/bus/usb,target=/dev/bus/usb,type=bind"
+	],
+	"runArgs": [
+		"--privileged"
+	]
+}
+```
+
+### Option 2: Docker CLI
+
+Run the container directly with USB access:
+
+```bash
+docker run --privileged -v /dev/bus/usb:/dev/bus/usb -it <container-id>
+```
+
+### Option 3: Modify devcontainer.json
+
+For permanent local changes, add to `.devcontainer/devcontainer.json`:
+
+```json
+"mounts": [
+	"source=/dev/bus/usb,target=/dev/bus/usb,type=bind"
+],
+"runArgs": [
+	"--privileged"
+]
+```
+
+Note: USB passthrough works best with Docker Desktop or local VS Code with Dev Containers. It is not available in GitHub Codespaces or CI environments.
 
 ## Configuration Details
 
 - **Base Image**: Microsoft Rust devcontainer (Debian Bookworm)
 - **Post-Create Setup**: Automatically installs probe-rs and configures Rust target
-- **USB Access**: Configured for ESP32 USB devices (vendor IDs: 303a, 10c4)
+- **USB Access**: Optional (see "Flashing to Hardware" section for enabling)
 - **VS Code Settings**: Pre-configured rust-analyzer for RISC-V embedded development
+- **CI/CD Ready**: Works in GitHub Actions and Codespaces without modification
 
 ## Troubleshooting
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,14 +27,6 @@
 		}
 	},
 
-	"mounts": [
-		"source=/dev/bus/usb,target=/dev/bus/usb,type=bind"
-	],
-
-	"runArgs": [
-		"--privileged"
-	],
-
 	"remoteEnv": {
 		"DEFMT_LOG": "info"
 	}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -19,16 +19,20 @@ rustup component add rust-src
 echo "Installing additional tools..."
 cargo install cargo-expand || true
 
-# Set up udev rules for probe-rs (if running with USB passthrough)
-echo "Configuring USB permissions..."
-cat > /tmp/99-probe-rs.rules << 'EOF'
+# Set up udev rules for probe-rs (only if /dev/bus/usb exists - i.e., local dev with USB passthrough)
+if [ -d "/dev/bus/usb" ]; then
+    echo "Configuring USB permissions..."
+    cat > /tmp/99-probe-rs.rules << 'EOF'
 # probe-rs rules
 SUBSYSTEM=="usb", ATTR{idVendor}=="303a", MODE="0666"
 SUBSYSTEM=="usb", ATTR{idVendor}=="10c4", MODE="0666"
 EOF
-sudo mv /tmp/99-probe-rs.rules /etc/udev/rules.d/ || true
-sudo udevadm control --reload-rules || true
-sudo udevadm trigger || true
+    sudo mv /tmp/99-probe-rs.rules /etc/udev/rules.d/ || true
+    sudo udevadm control --reload-rules || true
+    sudo udevadm trigger || true
+else
+    echo "USB devices not available (CI environment). Skipping udev configuration."
+fi
 
 echo "Development environment setup complete!"
 echo ""


### PR DESCRIPTION
Remove USB passthrough and privileged mode from default configuration to allow the devcontainer to work in GitHub Actions and Codespaces environments where /dev/bus/usb is not available.

Changes:
- Remove USB mount and --privileged flag from devcontainer.json
- Update setup.sh to conditionally configure udev rules only when USB exists
- Document three methods for enabling USB access in local development
- Mark configuration as CI/CD ready

The minimal configuration now focuses on building and testing, which works everywhere. Users who need to flash hardware can optionally enable USB support through local configuration overrides.