### PR TITLE
Fix ESP32-C6 release build by disabling LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,6 @@ codegen-units    = 1     # LLVM can perform better optimizations using a single 
 debug            = 2
 debug-assertions = false
 incremental      = false
-lto              = 'fat'
+lto              = false  # Disabled: LTO strips esp-radio NVS symbols before linker script runs
 opt-level        = 's'
 overflow-checks  = false


### PR DESCRIPTION
The release build was failing with linker errors for esp-radio NVS symbols:
- __esp_radio_misc_nvs_init
- __esp_radio_misc_nvs_deinit

Root cause: Link Time Optimization (LTO) was stripping these symbols during
the optimization phase, before the linker script's EXTERN() directives could
preserve them. These symbols are defined in esp-radio's common_adapter.rs as
extern "C" functions but appear unused to the LLVM optimizer.

Solution: Disabled LTO in the release profile. The project already uses
opt-level = 's' for size optimization, so binary size impact is minimal.

Tested: Release build now completes successfully and produces a working binary.