### PR TITLE
Fix clippy::empty_loop error by replacing empty loop with panic

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -207,7 +207,7 @@ async fn main(spawner: Spawner) -> ! {
                         Ok(v) => v,
                         Err(e) => {
                             error!("wifi new() failed: {:?}", e);
-                            loop {}
+                            panic!("wifi initialization failed");
                         }
                     };
 


### PR DESCRIPTION
Replace empty loop in Wi-Fi initialization error handler with panic!()
to properly indicate a fatal error condition and avoid wasting CPU cycles.