### PR TITLE
Add MQTT client setup with rust-mqtt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 ] }
 heapless = "0.8"
 static_cell = "2.1"
+rust-mqtt = { version = "0.3", default-features = false, features = ["defmt"] }
+embedded-nal-async = "0.8"
 
 
 [profile.dev]


### PR DESCRIPTION
- Add dependencies: rust-mqtt v0.3, embedded-nal-async v0.8 for MQTT client support
- Add MQTT configuration constants: broker host/port, keep-alive (60s), session expiry (3600s)
- Implement mqtt_connection_task with configuration logging and readiness signaling
- Update mqtt_publish_task to wait for MQTT connection before processing sensor readings
- Add MQTT_CONNECTED signal for inter-task coordination
- Update network_task documentation to clarify esp-radio's smoltcp stack integration
- Update CLAUDE.md and .junie/guidelines.md with MQTT infrastructure details

Note: This implements the configuration infrastructure and task structure for MQTT. Full TCP socket integration with esp-radio's smoltcp stack will be implemented in a follow-up, as rust-mqtt requires an embedded-io adapter for smoltcp TCP sockets.